### PR TITLE
feat(commit-msg): add conventional commits

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "husky": {
+      "version": "0.5.1",
+      "commands": [
+        "husky"
+      ]
+    }
+  }
+}

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,11 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+if ! head -1 "$1" | grep -qE "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.+?\))?: .{1,}$"; then
+    echo "Aborting commit. Your commit message is invalid." >&2
+    exit 1
+fi
+if ! head -1 "$1" | grep -qE "^.{1,50}$"; then
+    echo "Aborting commit. Your commit message is too long." >&2
+    exit 1
+fi

--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -1,0 +1,19 @@
+{
+   "tasks": [
+      {
+         "name": "dotnet-format-example",
+         "command": "dotnet",
+         "args": [ "dotnet-format", "--include", "${staged}" ],
+         "include": [ "**/*.cs", "**/*.vb" ]
+      },
+      {
+         "name": "welcome-message-example",
+         "command": "bash",
+         "args": [ "-c", "echo Husky.Net is awesome!" ],
+         "windows": {
+            "command": "cmd",
+            "args": ["/c", "echo Husky.Net is awesome!" ]
+         }
+      }
+   ]
+}


### PR DESCRIPTION
Added [Husky.net](https://alirezanet.github.io/Husky.Net/guide/getting-started.html#installation) to versionize used git hooks. The git hook commit-msg is used to enforce [convetional commits](https://www.conventionalcommits.org/en/v1.0.0/).

At the moment there isn't every specification validated by the git hook. The important one (prefix type, message length) are validated. The other validations can be added in future.

I didn't want to use the available npm tools because I didn't find it nice to use  [Nuget](https://www.nuget.org/) and [NPM](https://www.npmjs.com/) in the same project. Unfortunately I didn't find anybode who does this.