### PR TITLE
fix: failing unit tests

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/ExportKindleClippingsToNotion/Parser/ClippingsLanguage.cs
+++ b/ExportKindleClippingsToNotion/Parser/ClippingsLanguage.cs
@@ -18,7 +18,7 @@ public class ClippingsLanguage()
     public SupportedLanguages Determine(string clipping)
     {
         var secondLine = clipping
-            .Split("\r\n")
+            .Split("\n")
             .Where(line => line.Length > 0)
             .Select(line => line.Trim())
             .Select(line => line.Replace("\u200B", Empty))
@@ -29,7 +29,6 @@ public class ClippingsLanguage()
             throw new LanguageNotRecognizedException("The language of your clipping can't be recognized!");
         }
         
-        Console.Write(secondLine);
         foreach (var identifier in _languageIdentifiers
                      .Where(identifier => secondLine.Contains(identifier.Value)))
             return identifier.Key;


### PR DESCRIPTION
Unit Tests were failing because the all lines of a clipping were spilt by "\r\n". However this does also work with \n only.